### PR TITLE
[L/Settings] wrong titles

### DIFF
--- a/src/app/modules/settings/components/settings-users/settings-users.component.html
+++ b/src/app/modules/settings/components/settings-users/settings-users.component.html
@@ -1,7 +1,7 @@
 <h2>
   <img class="emoji" [src]="EmojiName.BustsInSilhouette | emoji" />
   <div class="d-inline-block">
-    {{ I18ns.leadTeam.teams.title }}
+    {{ I18ns.settings.users.admins }}
   </div>
 </h2>
 <p class="alto-grey descriptions mt-3 mb-4">


### PR DESCRIPTION
Ticket notion ~> https://www.notion.so/usealto/L-Settings-wrong-titles-4fd1a0530a2145b2a6574842a85c56e9?pvs=4

<img width="1204" alt="Capture d’écran 2023-08-16 à 15 25 32" src="https://github.com/usealto/assessment-front/assets/65304634/37d75975-2239-4f4d-aa93-3147eb3da10c">
