### PR TITLE
Cancel Cypress Github automation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,35 +1,35 @@
-name: Cypress Tests
+# name: Cypress Tests
 
-on: [pull_request]
+# on: [pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+#   cancel-in-progress: true
 
-jobs:
-  cypress-run:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+# jobs:
+#   cypress-run:
+#     runs-on: ubuntu-22.04
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@v4
 
-      - name: Create cypress.env.json
-        run: |
-          echo -n '{
-            "auth_audience": "'${{ secrets.CYPRESS_AUTH_AUDIENCE }}'",
-            "auth_url": "'${{ secrets.CYPRESS_AUTH_URL }}'",
-            "auth_client_id": "'${{ secrets.CYPRESS_AUTH_CLIENT_ID }}'",
-            "auth_client_secret": "'${{ secrets.CYPRESS_AUTH_CLIENT_SECRET }}'",
-            "auth_username-admin": "'${{ secrets.CYPRESS_AUTH_USERNAME_ADMIN }}'",
-            "auth_password-admin": "'${{ secrets.CYPRESS_AUTH_PASSWORD_ADMIN }}'",
-            "auth_username": "'${{ secrets.CYPRESS_AUTH_USERNAME }}'",
-            "auth_password": "'${{ secrets.CYPRESS_AUTH_PASSWORD }}'",
-            "apiURL": "'${{ secrets.CYPRESS_API_URL }}'"
-          }' > cypress.env.json
+#       - name: Create cypress.env.json
+#         run: |
+#           echo -n '{
+#             "auth_audience": "'${{ secrets.CYPRESS_AUTH_AUDIENCE }}'",
+#             "auth_url": "'${{ secrets.CYPRESS_AUTH_URL }}'",
+#             "auth_client_id": "'${{ secrets.CYPRESS_AUTH_CLIENT_ID }}'",
+#             "auth_client_secret": "'${{ secrets.CYPRESS_AUTH_CLIENT_SECRET }}'",
+#             "auth_username-admin": "'${{ secrets.CYPRESS_AUTH_USERNAME_ADMIN }}'",
+#             "auth_password-admin": "'${{ secrets.CYPRESS_AUTH_PASSWORD_ADMIN }}'",
+#             "auth_username": "'${{ secrets.CYPRESS_AUTH_USERNAME }}'",
+#             "auth_password": "'${{ secrets.CYPRESS_AUTH_PASSWORD }}'",
+#             "apiURL": "'${{ secrets.CYPRESS_API_URL }}'"
+#           }' > cypress.env.json
 
-      - name: Cypress run
-        uses: cypress-io/github-action@v6
-        with:
-          start: npm start
-          config-file: cypress/cypress-CICD.config.ts
-          wait-on: 'http://localhost:4200'
+#       - name: Cypress run
+#         uses: cypress-io/github-action@v6
+#         with:
+#           start: npm start
+#           config-file: cypress/cypress-CICD.config.ts
+#           wait-on: 'http://localhost:4200'


### PR DESCRIPTION
I suggest we cancel the cypress automation for Github action, because it fails in the CI process. We should try locally as a safety guard before pushing to develop/production. But it's currently a waste of CPU and github action usage. 

Not sure I did all the settings properly, so don't hesitate to request changes @Hugonotfound 