### PR TITLE
removing chartJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@usealto/sdk-ts-angular": "^1.0.202312061105-dev",
     "bootstrap": "^5.3.0",
     "bootstrap-icons": "^1.10.5",
-    "chart.js": "^4.2.1",
     "date-fns": "^2.29.3",
     "echarts": "^5.4.2",
     "memoizee": "^0.4.15",

--- a/src/app/modules/charts/chart-basicline/chart-basicline.component.html
+++ b/src/app/modules/charts/chart-basicline/chart-basicline.component.html
@@ -1,1 +1,1 @@
-<div *ngIf="lineOptions && this.isLoaded" echarts [options]="lineOptions" class="chart"></div>
+<div *ngIf="lineOptions && this.isLoaded" echarts [options]="lineOptions" class="chart" [initOpts]="initOptions"></div>

--- a/src/app/modules/charts/chart-basicline/chart-basicline.component.ts
+++ b/src/app/modules/charts/chart-basicline/chart-basicline.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, Input, OnChanges } from '@angular/core';
 import { EChartsOption } from 'echarts';
-import { ChartsService } from '../charts.service';
+import { ChartsService, initOptions } from '../charts.service';
 
 @Component({
   selector: 'alto-chart-basicline',
@@ -9,6 +9,7 @@ import { ChartsService } from '../charts.service';
 })
 export class ChartBasiclineComponent implements OnChanges, AfterViewInit {
   @Input() chartOption?: EChartsOption;
+  @Input() initOptions: initOptions = {}
 
   isLoaded = false;
   lineOptions?: EChartsOption;

--- a/src/app/modules/charts/charts.service.ts
+++ b/src/app/modules/charts/charts.service.ts
@@ -10,6 +10,17 @@ export interface ITooltipParams {
   color: string;
   seriesIndex: number;
 }
+export interface initOptions {
+  devicePixelRatio?: number,
+  renderer?: string,
+  useDirtyRect?: boolean,     // Since `5.0.0`
+  useCoarsePointer?: boolean, // Since `5.4.0`
+  pointerSize?: number,       // Since `5.4.0`
+  ssr?: boolean,              // Since `5.3.0`
+  width?: number|string,
+  height?: number|string,
+  locale?: string 
+}
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/modules/shared/constants/config.ts
+++ b/src/app/modules/shared/constants/config.ts
@@ -1,5 +1,3 @@
-import { ChartOptions } from 'chart.js';
-import Chart from 'chart.js/auto';
 import { I18ns } from 'src/app/core/utils/i18n/I18n';
 
 //! Changing this constant will change every charts using it!
@@ -34,75 +32,4 @@ export const yAxisScoreOptions: any = {
 export const legendOptions: any = {
   show: true,
   textStyle: { color: '#667085' },
-};
-
-// ! DEPRECATED for V3.2
-export const chartDefaultOptions: ChartOptions = {
-  maintainAspectRatio: false,
-  responsive: true,
-  plugins: {
-    tooltip: {
-      callbacks: {
-        label(tooltipItem) {
-          return `${tooltipItem.dataset.label}: ${tooltipItem.formattedValue}%`;
-        },
-      },
-    },
-    legend: {
-      display: false,
-      align: 'end',
-      labels: {
-        usePointStyle: true,
-        boxWidth: 5,
-        boxHeight: 5,
-        pointStyle: 'circle',
-      },
-    },
-  },
-  scales: {
-    x: {
-      display: true,
-      title: {
-        display: true,
-        text: I18ns.leadHome.graph.period,
-      },
-      grid: {
-        display: false,
-      },
-    },
-    y: {
-      display: true,
-      min: 0,
-      max: 105,
-      ticks: {
-        stepSize: 5,
-        callback: (val, index) => {
-          // No label for values other than multiples of 10
-          return +val % 10 === 0 ? val : '';
-        },
-      },
-      title: {
-        display: true,
-        text: I18ns.leadHome.graph.score,
-      },
-      grid: {
-        color: (context) => {
-          // No grid line for values other than multiples of 10
-          if (context.tick.value % 10 === 0) {
-            return Chart.defaults.borderColor.toString();
-          }
-          return '#00000000';
-        },
-      },
-    },
-  },
-  hover: {
-    mode: 'nearest',
-    intersect: false,
-  },
-  elements: {
-    point: {
-      hoverRadius: 10,
-    },
-  },
 };

--- a/src/app/modules/user-home/components/statistics/user-home-statistics.component.html
+++ b/src/app/modules/user-home/components/statistics/user-home-statistics.component.html
@@ -78,20 +78,24 @@
       </div>
     </div>
   </div>
-
-  <div class="col-9">
+  <alto-placeholder-manager class="col-9" [status]="userChartStatus">
     <div class="panel h-100">
       <h2>{{ I18ns.userHome.statistics.progression.title }}</h2>
-      <div [hidden]="!hasData" class="chart-container">
-        <canvas id="userProgressionChart"></canvas>
+      <div class="chart-container">
+        <alto-chart-basicline [chartOption]="userChartOptions" [initOptions]="{height: '280px'}"></alto-chart-basicline>
       </div>
-        <div [hidden]="hasData" class="chart-container">
-          <div class="text-center p-6 mb-4">
-            <i class="alto-badge-big fs-5 bi bi-file-text"></i>
-            <h2 class="my-4">{{ I18ns.userHome.statistics.progression.noData }}</h2>
-            <p>{{ I18ns.userHome.statistics.progression.noDataSubtitle }}</p>
-          </div>
-        </div>
     </div>
-  </div>
+    <div class="nodata-placeholder chart-container" empty>
+      <div class="text-center">
+        <img [src]="EmojiName.FourOclock | emoji" height="24" width="24" />
+        <p class="mt-3">
+          {{ I18ns.userHome.statistics.progression.noData }}
+        </p>
+        <span class="d-inline-block mt-3">
+          {{ I18ns.userHome.statistics.progression.noDataSubtitle }}
+        </span>
+      </div>
+    </div>
+    <div class="skeleton-panel mb-5" style="height: 497px" loading></div>
+  </alto-placeholder-manager>
 </div>

--- a/src/app/modules/user-home/components/statistics/user-home-statistics.component.ts
+++ b/src/app/modules/user-home/components/statistics/user-home-statistics.component.ts
@@ -17,6 +17,7 @@ import { EmojiName } from 'src/app/core/utils/emoji/data';
 import { PlaceholderDataStatus } from 'src/app/modules/shared/models/placeholder.model';
 import { legendOptions, xAxisDatesOptions, yAxisScoreOptions } from 'src/app/modules/shared/constants/config';
 import { Team } from 'src/app/models/team.model';
+import { EChartsOption, SeriesOption } from 'echarts';
 
 @Component({
   selector: 'alto-user-home-statistics',
@@ -44,7 +45,7 @@ export class UserHomeStatisticsComponent implements OnInit {
 
   EmojiName = EmojiName;
   userChartStatus: PlaceholderDataStatus = 'loading';
-  userChartOptions!: any;
+  userChartOptions!: EChartsOption;
 
   constructor(
     private readonly guessesRestService: GuessesRestService,
@@ -61,11 +62,7 @@ export class UserHomeStatisticsComponent implements OnInit {
     const data = this.resolversService.getDataFromPathFromRoot(this.activatedRoute.pathFromRoot);
     this.user = (data[EResolverData.AppData] as IAppData).me;
     const teamsById = (data[EResolverData.AppData] as IAppData).teamById;
-    if (!this.user.teamId || this.user.teamId === '' || teamsById.get(this.user.teamId) === undefined) {
-      console.log('error : no team for this user. Should not even be allowed on this page. Guards "noTeam" should be activated');
-    } else {
-      this.userTeam = teamsById.get(this.user.teamId) as Team;
-    }
+    this.userTeam = teamsById.get(this.user.teamId as string) as Team
     this.getScore();
     this.getUserChartScores(this.statisticsDuration);
     this.getFinishedPrograms();
@@ -214,7 +211,7 @@ export class UserHomeStatisticsComponent implements OnInit {
     this.userChartOptions = {
       xAxis: [{ ...xAxisDatesOptions, data: labels }],
       yAxis: [{ ...yAxisScoreOptions, axisLabel: { show: false } }],
-      series: series,
+      series: series as SeriesOption[],
       legend: {...legendOptions, top:5 },
     };
   }

--- a/src/app/modules/user-home/components/statistics/user-home-statistics.component.ts
+++ b/src/app/modules/user-home/components/statistics/user-home-statistics.component.ts
@@ -1,21 +1,22 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ScoreDtoApi, ScoreTimeframeEnumApi, ScoreTypeEnumApi } from '@usealto/sdk-ts-angular';
-import Chart, { ChartData } from 'chart.js/auto';
 import { combineLatest, map, tap } from 'rxjs';
 import { EResolverData, ResolversService } from 'src/app/core/resolvers/resolvers.service';
 import { I18ns } from 'src/app/core/utils/i18n/I18n';
 import { User } from 'src/app/models/user.model';
 import { ProgramRunsRestService } from 'src/app/modules/programs/services/program-runs-rest.service';
 import { ProgramsRestService } from 'src/app/modules/programs/services/programs-rest.service';
-import { chartDefaultOptions } from 'src/app/modules/shared/constants/config';
-import { ChartFilters } from 'src/app/modules/shared/models/chart.model';
 import { ScoreDuration } from 'src/app/modules/shared/models/score.model';
 import { ScoresRestService } from 'src/app/modules/shared/services/scores-rest.service';
 import { ScoresService } from 'src/app/modules/shared/services/scores.service';
 import { StatisticsService } from 'src/app/modules/statistics/services/statistics.service';
 import { GuessesRestService } from 'src/app/modules/training/services/guesses-rest.service';
 import { IAppData } from '../../../../core/resolvers';
+import { EmojiName } from 'src/app/core/utils/emoji/data';
+import { PlaceholderDataStatus } from 'src/app/modules/shared/models/placeholder.model';
+import { legendOptions, xAxisDatesOptions, yAxisScoreOptions } from 'src/app/modules/shared/constants/config';
+import { Team } from 'src/app/models/team.model';
 
 @Component({
   selector: 'alto-user-home-statistics',
@@ -24,9 +25,11 @@ import { IAppData } from '../../../../core/resolvers';
 })
 export class UserHomeStatisticsComponent implements OnInit {
   I18ns = I18ns;
+  // could be replaced by duration bellow
   statisticsDuration = ScoreDuration.Trimester;
 
   user!: User;
+  userTeam!: Team;
   //Statistics data
   userScore = 0;
   userScoreProgression = 0;
@@ -38,8 +41,10 @@ export class UserHomeStatisticsComponent implements OnInit {
   averageFinishedPrograms = 0;
   finishedProgramsCountProgression = 0;
 
-  userProgressionChart?: Chart;
-  hasData = true;
+
+  EmojiName = EmojiName;
+  userChartStatus: PlaceholderDataStatus = 'loading';
+  userChartOptions!: any;
 
   constructor(
     private readonly guessesRestService: GuessesRestService,
@@ -55,10 +60,16 @@ export class UserHomeStatisticsComponent implements OnInit {
   ngOnInit(): void {
     const data = this.resolversService.getDataFromPathFromRoot(this.activatedRoute.pathFromRoot);
     this.user = (data[EResolverData.AppData] as IAppData).me;
+    const teamsById = (data[EResolverData.AppData] as IAppData).teamById;
+    if (!this.user.teamId || this.user.teamId === '' || teamsById.get(this.user.teamId) === undefined) {
+      console.log('error : no team for this user. Should not even be allowed on this page. Guards "noTeam" should be activated');
+    } else {
+      this.userTeam = teamsById.get(this.user.teamId) as Team;
+    }
     this.getScore();
+    this.getUserChartScores(this.statisticsDuration);
     this.getFinishedPrograms();
     this.getGuessesCount();
-    this.createUserProgressionChart();
   }
 
   getScore() {
@@ -75,6 +86,29 @@ export class UserHomeStatisticsComponent implements OnInit {
           this.userScore = curr[0]?.score ?? 0;
           const previousScore = prev[0]?.score ?? 0;
           this.userScoreProgression = previousScore && this.userScore ? this.userScore - previousScore : 0;
+        }),
+      )
+      .subscribe();
+  }
+
+  getUserChartScores(duration: ScoreDuration): void {
+    this.userChartStatus = 'loading';
+
+    const timeframe = (duration: ScoreDuration) =>
+      duration === ScoreDuration.Year
+        ? ScoreTimeframeEnumApi.Month
+        : duration === ScoreDuration.Trimester
+        ? ScoreTimeframeEnumApi.Week
+        : ScoreTimeframeEnumApi.Day;
+
+    combineLatest([
+      this.scoresRestService.getScores({type:ScoreTypeEnumApi.User, duration: this.statisticsDuration, ids: [this.user.id], timeframe: timeframe(this.statisticsDuration)}),
+      this.scoresRestService.getScores({type:ScoreTypeEnumApi.Team, duration: this.statisticsDuration, ids: [this.userTeam.id], timeframe: timeframe(this.statisticsDuration)}),
+    ])
+      .pipe(
+        tap(([userScores, teamScores]) => {
+          this.createUserChart(userScores.scores[0], teamScores.scores[0], duration);
+          this.userChartStatus = userScores.scores.length > 0 ? 'good' : 'empty';
         }),
       )
       .subscribe();
@@ -144,114 +178,52 @@ export class UserHomeStatisticsComponent implements OnInit {
       )
       .subscribe();
   }
-  createUserProgressionChart() {
-    const params = {
-      timeframe: ScoreTimeframeEnumApi.Day,
-      duration: this.statisticsDuration,
-    } as ChartFilters;
 
-    combineLatest([
-      this.scoresRestService.getScores({
-        ...params,
-        type: ScoreTypeEnumApi.User,
-      }),
-      this.scoresRestService.getScores({
-        ...params,
-        type: ScoreTypeEnumApi.Team,
-      }),
-    ])
-      .pipe(
-        tap(([usersScores, teamsScores]) => {
-          //USER SCORES: reduce scores to remove all first values without data
-          const rawUserScores = usersScores.scores.find((u) => u.id === this.user.id);
-          if (!rawUserScores) {
-            this.hasData = false;
-            return;
-          }
-          const reducedUserScores = this.scoresService.reduceLineChartData([
-            rawUserScores ?? ({} as ScoreDtoApi),
-          ]);
+  createUserChart(userScores: ScoreDtoApi, teamScores: ScoreDtoApi, duration: ScoreDuration): void {
+    const reducedTeamScores = this.scoresService.reduceLineChartData([teamScores])[0];
+    const teamPoints = this.statisticsService.transformDataToPoint(reducedTeamScores);
 
-          const userScores = this.statisticsService.aggregateDataForScores(
-            reducedUserScores[0],
-            this.statisticsDuration,
-          );
+    const labels = this.statisticsService.formatLabel(
+      teamPoints.map((d) => d.x),
+      duration,
+    );
 
-          //TEAM SCORES: reduce scores to remove all first values without data
-          const rawTeamScores = teamsScores.scores.find((t) => t.id === this.user.teamId);
-          const reducedTeamScores = this.scoresService.reduceLineChartData([
-            rawTeamScores ?? ({} as ScoreDtoApi),
-          ]);
+    const dataSets = [userScores, teamScores].map((scores,i) => {
+      const d = this.statisticsService.transformDataToPoint(scores);
+      return {
+        label: (i === 0) ? I18ns.userHome.statistics.progression.you : I18ns.userHome.statistics.progression.yourTeam + ` (${scores.label}) `,
+        data: d.map((d) => (d.y ? Math.round((d.y * 10000) / 100) : d.y)),
+      };
+    });
 
-          const teamScores = this.statisticsService.aggregateDataForScores(
-            reducedTeamScores[0],
-            this.statisticsDuration,
-          );
+    const series = dataSets.map((d,i) => {
+      return {
+        name: d.label,
+        data: d.data,
+        type: 'line',
+        showSymbol: false,
+        tooltip: {
+          valueFormatter: (value: any) => {
+            return (value as number) + '%';
+          },
+        },
+        lineStyle: (i === 0) ? {} : {type: 'dashed'},
+      };
+    });
 
-          const labels = this.statisticsService.formatLabel(
-            userScores.map((d) => d.x),
-            this.statisticsDuration,
-          );
-          const data: ChartData = {
-            labels: labels,
-            datasets: [
-              {
-                label: I18ns.userHome.statistics.progression.you,
-                data: userScores.map((d) => (d.y ? Math.round((d.y * 10000) / 100) : d.y)),
-                fill: false,
-                tension: 0.2,
-                spanGaps: true,
-              },
-              {
-                label: I18ns.userHome.statistics.progression.yourTeam,
-                data: teamScores.map((d) => (d.y ? Math.round((d.y * 10000) / 100) : d.y)),
-                fill: false,
-                tension: 0.2,
-                borderDash: [4],
-                spanGaps: true,
-              },
-            ],
-          };
-
-          if (this.userProgressionChart) {
-            this.userProgressionChart.destroy();
-          }
-          const customChartOptions = {
-            ...chartDefaultOptions,
-            plugins: {
-              tooltip: {
-                callbacks: {
-                  label: function (tooltipItem: any) {
-                    return `${tooltipItem.dataset.label}: ${tooltipItem.formattedValue}%`;
-                  },
-                },
-              },
-              legend: {
-                display: true,
-                labels: {
-                  usePointStyle: true,
-                  boxWidth: 5,
-                  boxHeight: 5,
-                  pointStyle: 'circle',
-                },
-              },
-            },
-          };
-          this.userProgressionChart = new Chart('userProgressionChart', {
-            type: 'line',
-            data: data,
-            options: customChartOptions,
-          });
-        }),
-      )
-      .subscribe();
+    this.userChartOptions = {
+      xAxis: [{ ...xAxisDatesOptions, data: labels }],
+      yAxis: [{ ...yAxisScoreOptions, axisLabel: { show: false } }],
+      series: series,
+      legend: {...legendOptions, top:5 },
+    };
   }
 
   updateTimePicker(duration: any) {
     this.statisticsDuration = duration;
     this.getScore();
+    this.getUserChartScores(duration);
     this.getFinishedPrograms();
     this.getGuessesCount();
-    this.createUserProgressionChart();
   }
 }

--- a/src/app/modules/user-home/user-home.module.ts
+++ b/src/app/modules/user-home/user-home.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { ChartsModule } from '../charts/charts.module';
 import { UserHomeRoutingModule } from './user-home-routing.module';
 import { UserHomeComponent } from './components/user-home/user-home.component';
 import { SharedModule } from '../shared/shared.module';
@@ -8,6 +8,6 @@ import { UserHomeStatisticsComponent } from './components/statistics/user-home-s
 
 @NgModule({
   declarations: [UserHomeComponent, UserHomeStatisticsComponent],
-  imports: [CommonModule, UserHomeRoutingModule, SharedModule],
+  imports: [CommonModule, UserHomeRoutingModule, SharedModule, ChartsModule],
 })
 export class UserHomeModule {}


### PR DESCRIPTION

# remove ChartJS
This pull request has one mainobjective : to remove the npm chartJS

- in terms of components, only on the page /u/home was chartjs still present
- in terms of refacto, I kept it to the minimum, and tried to stay close to what we did on the /l/stats/user/perf echart component
